### PR TITLE
Recreate classic macOS and iOS portfolio experience

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -135,6 +135,14 @@ body.ios-mode .mac-window { border-radius: 10px; border: 1px solid rgba(0,0,0,0.
   cursor: move;
 }
 .title-bar .title { text-shadow: 1px 1px 0 rgba(0,0,0,0.2); }
+/* Aqua pinstripes overlay */
+.title-bar::after {
+  content: "";
+  position: absolute; inset: 0;
+  background: repeating-linear-gradient( 0deg, rgba(255,255,255,0.25) 0px, rgba(255,255,255,0.25) 2px, rgba(0,0,0,0.04) 2px, rgba(0,0,0,0.04) 4px);
+  pointer-events: none;
+  opacity: 0.6;
+}
 body.ios-mode .title-bar { border-bottom-color: rgba(0,0,0,0.2); border-top-left-radius: 10px; border-top-right-radius: 10px; }
 .mac-window.active.ios-header .title-bar { background: linear-gradient(#5c8bff, #3f6af1); }
 .title-bar .title { font-size: 13px; font-weight: 600; margin: 0; }
@@ -216,9 +224,8 @@ body.ios-mode .dock { background: rgba(255,255,255,0.9); border-color: rgba(0,0,
 .ios-title { justify-self: center; font-weight: 600; }
 .app-body { padding: 12px; overflow: auto; }
 
-/* iOS app open animation */
-@keyframes iosOpen { 0% { transform: scale(0.92); opacity: 0; } 100% { transform: scale(1); opacity: 1; } }
-.ios-app.opening { animation: iosOpen 240ms ease-out; transform-origin: 50% 50%; }
+/* iOS app open animation support */
+.ios-app { transition: transform 260ms cubic-bezier(0.2, 0.9, 0.2, 1), opacity 200ms ease-out; transform-origin: 50% 50%; }
 
 /* Responsive: small screens open windows "maximized" */
 @media (max-width: 640px) {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -271,3 +271,12 @@ body.ios-mode .about .avatar { border-radius: 12px; border-color: rgba(0,0,0,0.4
 /* App name highlight when active window changes */
 .app-name { transition: background-color 120ms ease, color 120ms ease; }
 .app-name.active { background: #3466ff; color: #fff; border-color: #123aa8; box-shadow: inset 1px 1px 0 rgba(255,255,255,0.7); }
+
+/* Boot overlay */
+#boot-overlay { position: fixed; inset: 0; background: #000; display: none; align-items: center; justify-content: center; z-index: 2000; }
+#boot-overlay.active { display: flex; }
+.boot-inner { display: flex; flex-direction: column; align-items: center; gap: 18px; color: #fff; position: relative; }
+.boot-inner::before { content: ""; position: absolute; inset: -20vh -20vw; pointer-events: none; background: radial-gradient(60vh 40vh at 50% 40%, rgba(255,255,255,0.08), rgba(0,0,0,0) 70%); }
+.boot-apple { filter: drop-shadow(0 0 14px rgba(255,255,255,0.25)); }
+.boot-progress { width: 240px; height: 6px; border-radius: 4px; background: rgba(255,255,255,0.18); overflow: hidden; border: 1px solid rgba(255,255,255,0.28); box-shadow: inset 0 1px 0 rgba(255,255,255,0.35), 0 2px 10px rgba(0,0,0,0.6); }
+.boot-bar { width: 0%; height: 100%; background: linear-gradient(90deg, #b7d0ff, #6da0ff); box-shadow: 0 0 10px rgba(109,160,255,0.6); transition: width 180ms ease; }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,7 +1,7 @@
 /* Basic Reset */
 * { box-sizing: border-box; }
 html, body { height: 100%; }
-body { margin: 0; font-family: Charcoal, Chicago, Geneva, Tahoma, Arial, sans-serif; color: #000; background: #c7c7c7; }
+body { margin: 0; font-family: "Lucida Grande", "Lucida Sans Unicode", Helvetica, Arial, sans-serif; color: #000; background: #c7c7c7; }
 body.ios-mode { background: #cfd6df; font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; }
 
 /* Desktop Background: Mac OS 9 Platinum pinstripes */
@@ -21,7 +21,7 @@ body.ios-mode #desktop { background: #dbe2ea; height: 100vh; padding-top: 28px; 
   align-items: center;
   justify-content: space-between;
   padding: 0 8px;
-  background: linear-gradient(#efefef, #cfcfcf);
+  background: linear-gradient(#f5f5f5, #d7d7d7);
   border-bottom: 1px solid #000;
   position: sticky;
   top: 0;
@@ -116,7 +116,7 @@ body.ios-mode .desktop-icon .icon-label { background: rgba(255,255,255,0.8); bor
   grid-template-rows: 22px 1fr;
 }
 .mac-window.platinum .title-bar { background: linear-gradient(#e7e7e7, #cfcfcf); }
-.mac-window.active.platinum .title-bar { background: linear-gradient(#0041ff, #0030cc); color: #fff; }
+.mac-window.active.platinum .title-bar { background: linear-gradient(#4a77ff, #2f5ef4); color: #fff; }
 body.ios-mode .mac-window { border-radius: 10px; border: 1px solid rgba(0,0,0,0.6); box-shadow: 0 6px 16px rgba(0,0,0,0.25); }
 .mac-window[hidden] { display: none !important; }
 .mac-window.active .title-bar { background: linear-gradient(#2d63f0, #1745d8); color: #fff; }
@@ -140,56 +140,65 @@ body.ios-mode .title-bar { border-bottom-color: rgba(0,0,0,0.2); border-top-left
 }
 .control {
   width: 14px; height: 14px;
-  border: 1px solid #000;
-  background: #e5e5e5;
-  box-shadow: inset -1px -1px 0 #000, inset 1px 1px 0 #fff;
-  padding: 0; cursor: default;
+  border-radius: 50%;
+  border: 1px solid rgba(0,0,0,0.6);
+  background: radial-gradient(circle at 30% 30%, rgba(255,255,255,0.95), rgba(255,255,255,0.2)),
+              linear-gradient(#d0d0d0, #b6b6b6);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.8), inset 0 -1px 0 rgba(0,0,0,0.1);
+  padding: 0; cursor: default; position: relative;
 }
-body.ios-mode .control { border-radius: 50%; border-color: rgba(0,0,0,0.5); box-shadow: inset 0 1px 0 rgba(255,255,255,0.6); }
-.control.close { background: repeating-linear-gradient(45deg, #e5e5e5, #e5e5e5 2px, #c5c5c5 2px, #c5c5c5 4px); }
-.control.minimize { background: linear-gradient(#f3f3f3, #cfcfcf); }
-.control.zoom { background: linear-gradient(#f3f3f3, #cfcfcf); }
+.control::before { content: ""; position: absolute; inset: 0; border-radius: 50%; box-shadow: inset 0 0 0 1px rgba(255,255,255,0.6); }
+.control.close { background: radial-gradient(circle at 30% 30%, rgba(255,255,255,0.9), rgba(255,255,255,0.15)), linear-gradient(#ff6b63, #d9332a); }
+.control.minimize { background: radial-gradient(circle at 30% 30%, rgba(255,255,255,0.9), rgba(255,255,255,0.15)), linear-gradient(#ffd86b, #dea81f); }
+.control.zoom { background: radial-gradient(circle at 30% 30%, rgba(255,255,255,0.9), rgba(255,255,255,0.15)), linear-gradient(#6bff7d, #18b243); }
+.controls:hover .control::after { color: rgba(0,0,0,0.8); font-size: 10px; line-height: 14px; text-align: center; position: absolute; inset: 0; }
+.controls:hover .control.close::after { content: "×"; }
+.controls:hover .control.minimize::after { content: "–"; }
+.controls:hover .control.zoom::after { content: "+"; }
 .window-content { padding: 10px; overflow: auto; font-size: 14px; }
 body.ios-mode .window-content { padding: 12px; font-size: 15px; }
 .resize-handle { position: absolute; right: 0; bottom: 0; width: 12px; height: 12px; background: linear-gradient(135deg, transparent 50%, #000 50%); cursor: nwse-resize; }
 body.ios-mode .resize-handle { display: none; }
 
-.list { list-style: none; padding: 0; margin: 0; }
-.list li { padding: 6px 0; border-bottom: 1px solid #eaeaea; }
-.list li:last-child { border-bottom: none; }
+/* Hide desktop chrome in iOS mode; show SpringBoard */
+body.ios-mode .mac-window,
+body.ios-mode .desktop-icons { display: none !important; }
+body.ios-mode #springboard { display: grid; }
+body.ios-mode .home-button { display: block; }
 
-.contact { list-style: none; padding: 0; margin: 0; }
-.contact li { margin-bottom: 6px; }
-.contact a { color: #0645ad; text-decoration: underline; }
-
-/* Media section */
-.media { margin-top: 10px; }
-.media h3 { margin: 10px 0 6px; font-size: 14px; }
-.video-item { margin-bottom: 12px; }
-.podcast-embed { margin-top: 8px; }
-.podcast-embed .podcast-link { margin: 6px 0 0; font-size: 12px; }
-
-/* About This Mac */
-.about-mac { display: flex; align-items: center; gap: 12px; }
-.about-mac .os-name { font-weight: 700; }
-.about-mac .os-version { font-size: 12px; color: #333; }
-.about-mac .machine { font-size: 12px; }
-
-/* Boot overlay */
-#boot-overlay { position: fixed; inset: 0; background: #000; display: none; align-items: center; justify-content: center; z-index: 2000; }
-#boot-overlay.active { display: flex; }
-.boot-inner { display: flex; flex-direction: column; align-items: center; gap: 14px; color: #fff; }
-.boot-spinner { width: 24px; height: 24px; border: 2px solid rgba(255,255,255,0.3); border-top-color: #fff; border-radius: 50%; animation: spin 1s linear infinite; }
-@keyframes spin { to { transform: rotate(360deg); } }
-
-/* Minimized windows dock (simple) */
+/* Improved Dock */
 .dock {
-  position: fixed; bottom: 6px; left: 50%; transform: translateX(-50%);
-  background: #dfdfdf; border: 1px solid #000; box-shadow: 2px 2px 0 #000; padding: 4px 6px; display: flex; gap: 6px;
+  position: fixed; bottom: 12px; left: 50%; transform: translateX(-50%);
+  display: flex; gap: 14px; align-items: flex-end; padding: 10px 14px;
+  background: rgba(255,255,255,0.35);
+  border: 1px solid rgba(0,0,0,0.2);
+  border-radius: 16px;
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+  box-shadow: 0 12px 24px rgba(0,0,0,0.25), inset 0 1px 0 rgba(255,255,255,0.6);
+  z-index: 1000;
 }
-.dock button { font-size: 12px; border: 1px solid #000; background: #cfcfcf; padding: 2px 6px; cursor: default; }
+.dock .dock-icon { width: 48px; height: 48px; border-radius: 12px; display: grid; place-items: center; position: relative; transform-origin: bottom center; transition: transform 0.08s linear; cursor: default; }
+.dock .dock-icon img, .dock .dock-icon svg { width: 36px; height: 36px; filter: drop-shadow(0 1px 0 rgba(255,255,255,0.6)); }
+.dock .label { position: absolute; bottom: 64px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.8); color: #fff; font-size: 11px; padding: 3px 6px; border-radius: 6px; white-space: nowrap; opacity: 0; pointer-events: none; transition: opacity 0.12s ease; }
+.dock .dock-icon:hover .label { opacity: 1; }
+.dock .indicator { position: absolute; bottom: 6px; left: 50%; width: 6px; height: 6px; background: rgba(0,0,0,0.7); border-radius: 50%; transform: translateX(-50%); opacity: 0; transition: opacity 0.2s; }
+.dock .dock-icon.active .indicator { opacity: 1; }
+@keyframes bounce { 0% { transform: translateY(0) scale(var(--mag,1)); } 30% { transform: translateY(-12px) scale(var(--mag,1)); } 60% { transform: translateY(0) scale(var(--mag,1)); } 80% { transform: translateY(-6px) scale(var(--mag,1)); } 100% { transform: translateY(0) scale(var(--mag,1)); } }
+.dock .dock-icon.bounce { animation: bounce 0.6s ease-out; }
 body.ios-mode .dock { background: rgba(255,255,255,0.9); border-color: rgba(0,0,0,0.2); box-shadow: 0 4px 12px rgba(0,0,0,0.15); border-radius: 10px; }
-body.ios-mode .dock button { border-color: rgba(0,0,0,0.4); background: #f3f3f3; border-radius: 6px; }
+
+/* iOS 4 SpringBoard */
+#springboard { display: none; grid-template-rows: 1fr auto; height: 100vh; padding: 24px 12px 64px; background: radial-gradient(circle at 30% 20%, #2d5bd1, #0f2a69 60%); }
+.springboard-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px 10px; align-content: start; }
+.sb-icon { display: grid; place-items: center; width: 64px; height: 64px; margin: 0 auto; border-radius: 14px; position: relative; box-shadow: 0 6px 14px rgba(0,0,0,0.35), inset 0 1px 0 rgba(255,255,255,0.55); background: linear-gradient(#7aa9ff, #2f6bff); }
+.sb-icon::after { content: ""; position: absolute; top: 0; left: 0; right: 0; height: 50%; border-radius: 14px 14px 10px 10px; background: linear-gradient(180deg, rgba(255,255,255,0.65), rgba(255,255,255,0)); pointer-events: none; }
+.sb-label { text-align: center; color: #fff; font-size: 11px; margin-top: 6px; text-shadow: 0 1px 0 rgba(0,0,0,0.7); }
+.ios-dock { position: fixed; left: 50%; transform: translateX(-50%); bottom: 10px; width: calc(100% - 24px); max-width: 480px; height: 66px; padding: 8px 16px; background: rgba(255,255,255,0.25); border: 1px solid rgba(255,255,255,0.3); border-radius: 18px; -webkit-backdrop-filter: blur(12px) saturate(1.2); backdrop-filter: blur(12px) saturate(1.2); box-shadow: inset 0 1px 0 rgba(255,255,255,0.6), 0 10px 20px rgba(0,0,0,0.35); display: grid; grid-auto-flow: column; justify-content: space-between; align-items: end; }
+.ios-dock .sb-icon { width: 56px; height: 56px; border-radius: 12px; }
+@keyframes jiggle { 0% { transform: rotate(-1.5deg) scale(0.98); } 50% { transform: rotate(1.5deg) scale(1.02); } 100% { transform: rotate(-1.5deg) scale(0.98); } }
+.jiggle .sb-icon { animation: jiggle 0.25s ease-in-out infinite; transform-origin: 50% 100%; }
+.home-button { display: none; position: fixed; bottom: 82px; left: 50%; transform: translateX(-50%); width: 58px; height: 58px; border-radius: 50%; background: radial-gradient(circle at 30% 30%, #fff, #e9e9e9); border: 1px solid rgba(0,0,0,0.4); box-shadow: 0 6px 14px rgba(0,0,0,0.25), inset 0 2px 0 rgba(255,255,255,0.8); }
 
 /* Responsive: small screens open windows "maximized" */
 @media (max-width: 640px) {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -238,3 +238,36 @@ body.ios-mode .dock { background: rgba(255,255,255,0.9); border-color: rgba(0,0,
 .about .avatar { border: 1px solid #000; box-shadow: 2px 2px 0 #000; background: #fff; }
 body.ios-mode .about .avatar { border-radius: 12px; border-color: rgba(0,0,0,0.4); box-shadow: 0 2px 8px rgba(0,0,0,0.2); }
 @media (max-width: 520px) { .about { grid-template-columns: 64px 1fr; } .about .avatar { width: 64px; height: 64px; } }
+
+/* iOS 4 Lock Screen */
+#lock-screen { position: fixed; inset: 0; display: none; align-items: flex-end; justify-content: center; background: #000; z-index: 2000; }
+#lock-screen .lock-bg { position: absolute; inset: 0; background:
+  radial-gradient(1200px 700px at 30% -10%, rgba(255,255,255,0.35), rgba(255,255,255,0) 60%),
+  radial-gradient(1000px 700px at 70% 120%, rgba(255,255,255,0.25), rgba(255,255,255,0) 60%),
+  linear-gradient(180deg, #3d74d8, #14305e 70%);
+  opacity: 0.7; filter: blur(1px);
+}
+#lock-screen .lock-time { position: absolute; top: 20%; color: #fff; font-weight: 400; font-size: 64px; letter-spacing: -1px; text-shadow: 0 2px 6px rgba(0,0,0,0.7); }
+#lock-screen .lock-slider { position: relative; width: 86%; max-width: 520px; margin: 0 0 48px; height: 46px; border-radius: 24px; border: 1px solid rgba(255,255,255,0.4); background: rgba(0,0,0,0.35); -webkit-backdrop-filter: blur(6px); backdrop-filter: blur(6px); box-shadow: inset 0 1px 0 rgba(255,255,255,0.5), 0 3px 10px rgba(0,0,0,0.5); display: grid; align-items: center; }
+#lock-screen .slider-track { color: rgba(255,255,255,0.85); text-transform: lowercase; font-size: 16px; text-align: center; overflow: hidden; position: relative; }
+#lock-screen .slider-track span { position: relative; }
+#lock-screen .slider-track::after { content: ""; position: absolute; inset: 0; background: linear-gradient(120deg, rgba(255,255,255,0) 0%, rgba(255,255,255,0.6) 50%, rgba(255,255,255,0) 100%); animation: shimmer 1.6s linear infinite; }
+#lock-screen .slider-thumb { position: absolute; left: 4px; top: 4px; width: 38px; height: 38px; border-radius: 19px; background: linear-gradient(#cfd7e6, #8a9bb6); border: 1px solid rgba(0,0,0,0.4); box-shadow: inset 0 1px 0 rgba(255,255,255,0.8), 0 2px 6px rgba(0,0,0,0.4); }
+@keyframes shimmer { 0% { transform: translateX(-100%); } 100% { transform: translateX(100%); } }
+
+/* SpringBoard paging */
+.sb-pages { height: calc(100% - 90px); overflow: hidden; position: relative; }
+.sb-pages .sb-page { position: absolute; inset: 0; }
+.page-dots { position: absolute; bottom: 84px; left: 50%; transform: translateX(-50%); display: flex; gap: 8px; }
+.page-dots span { width: 8px; height: 8px; border-radius: 50%; background: rgba(255,255,255,0.55); box-shadow: 0 1px 0 rgba(0,0,0,0.6); }
+.page-dots span.active { background: #fff; }
+
+/* Aqua scrollbars approximation */
+* { scrollbar-width: thin; scrollbar-color: #9fb7ff #e6ecff; }
+*::-webkit-scrollbar { width: 12px; height: 12px; }
+*::-webkit-scrollbar-track { background: linear-gradient(#f3f6ff, #dde7ff); box-shadow: inset 0 0 0 1px rgba(0,0,0,0.15); }
+*::-webkit-scrollbar-thumb { background: linear-gradient(#b7c8ff, #8aa6ff); border: 1px solid rgba(0,0,0,0.25); border-radius: 6px; box-shadow: inset 0 1px 0 rgba(255,255,255,0.7); }
+
+/* App name highlight when active window changes */
+.app-name { transition: background-color 120ms ease, color 120ms ease; }
+.app-name.active { background: #3466ff; color: #fff; border-color: #123aa8; box-shadow: inset 1px 1px 0 rgba(255,255,255,0.7); }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -4,11 +4,14 @@ html, body { height: 100%; }
 body { margin: 0; font-family: "Lucida Grande", "Lucida Sans Unicode", Helvetica, Arial, sans-serif; color: #000; background: #c7c7c7; }
 body.ios-mode { background: #cfd6df; font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; }
 
-/* Desktop Background: Mac OS 9 Platinum pinstripes */
+/* Desktop Background: Mac OS X 10.0 Aqua Blue */
 #desktop {
   position: relative;
   height: calc(100vh - 22px);
-  background: repeating-linear-gradient(0deg, #d9d9d9 0px, #d9d9d9 2px, #cfcfcf 2px, #cfcfcf 4px);
+  background:
+    radial-gradient(1200px 600px at 20% -10%, #9ad3ff 0%, rgba(154,211,255,0) 70%),
+    radial-gradient(900px 500px at 80% 110%, #2e74ff 0%, rgba(46,116,255,0) 70%),
+    linear-gradient(180deg, #8cc6ff 0%, #4ca1ff 45%, #1b6eff 100%);
   padding: 12px;
   overflow: hidden;
 }
@@ -28,7 +31,7 @@ body.ios-mode #desktop { background: #dbe2ea; height: 100vh; padding-top: 28px; 
   z-index: 1000;
   user-select: none;
 }
-.app-name { font-size: 12px; margin: 0 6px 0 4px; padding: 0 6px; border: 1px solid transparent; }
+.app-name { font-size: 13px; margin: 0 6px 0 4px; padding: 0 6px; border: 1px solid transparent; }
 .menu-left { display: flex; align-items: center; gap: 6px; position: relative; }
 /* Apple dropdown */
 .apple-dropdown { display: none; position: absolute; top: 20px; left: 0; background: #efefef; border: 1px solid #000; box-shadow: 2px 2px 0 #000; list-style: none; margin: 0; padding: 4px 0; z-index: 1002; }
@@ -62,7 +65,7 @@ body.ios-mode .status-bar { display: flex; }
 .menu-trigger {
   height: 20px;
   padding: 0 6px;
-  font-size: 12px;
+  font-size: 13px;
   border: 1px solid transparent;
   background: transparent;
   cursor: default;
@@ -126,7 +129,7 @@ body.ios-mode .mac-window { border-radius: 10px; border: 1px solid rgba(0,0,0,0.
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 0 6px 0 70px; /* room for controls on the left (mirroring classic) */
+  padding: 0 8px 0 68px; /* room for controls on the left */
   border-bottom: 1px solid #000;
   user-select: none;
   cursor: move;
@@ -134,9 +137,9 @@ body.ios-mode .mac-window { border-radius: 10px; border: 1px solid rgba(0,0,0,0.
 .title-bar .title { text-shadow: 1px 1px 0 rgba(0,0,0,0.2); }
 body.ios-mode .title-bar { border-bottom-color: rgba(0,0,0,0.2); border-top-left-radius: 10px; border-top-right-radius: 10px; }
 .mac-window.active.ios-header .title-bar { background: linear-gradient(#5c8bff, #3f6af1); }
-.title-bar .title { font-size: 12px; font-weight: 600; margin: 0; }
+.title-bar .title { font-size: 13px; font-weight: 600; margin: 0; }
 .controls {
-  position: absolute; left: 6px; top: 2px; display: flex; gap: 6px;
+  position: absolute; left: 7px; top: 3px; display: flex; gap: 7px;
 }
 .control {
   width: 14px; height: 14px;
@@ -165,6 +168,7 @@ body.ios-mode .mac-window,
 body.ios-mode .desktop-icons { display: none !important; }
 body.ios-mode #springboard { display: grid; }
 body.ios-mode .home-button { display: block; }
+body.ios-mode .dock { display: none !important; }
 
 /* Improved Dock */
 .dock {
@@ -182,23 +186,39 @@ body.ios-mode .home-button { display: block; }
 .dock .dock-icon img, .dock .dock-icon svg { width: 36px; height: 36px; filter: drop-shadow(0 1px 0 rgba(255,255,255,0.6)); }
 .dock .label { position: absolute; bottom: 64px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.8); color: #fff; font-size: 11px; padding: 3px 6px; border-radius: 6px; white-space: nowrap; opacity: 0; pointer-events: none; transition: opacity 0.12s ease; }
 .dock .dock-icon:hover .label { opacity: 1; }
-.dock .indicator { position: absolute; bottom: 6px; left: 50%; width: 6px; height: 6px; background: rgba(0,0,0,0.7); border-radius: 50%; transform: translateX(-50%); opacity: 0; transition: opacity 0.2s; }
+.dock .indicator { position: absolute; bottom: 0; left: 50%; transform: translateX(-50%); width: 0; height: 0; border-left: 5px solid transparent; border-right: 5px solid transparent; border-top: 7px solid rgba(0,0,0,0.8); opacity: 0; transition: opacity 0.2s; }
 .dock .dock-icon.active .indicator { opacity: 1; }
 @keyframes bounce { 0% { transform: translateY(0) scale(var(--mag,1)); } 30% { transform: translateY(-12px) scale(var(--mag,1)); } 60% { transform: translateY(0) scale(var(--mag,1)); } 80% { transform: translateY(-6px) scale(var(--mag,1)); } 100% { transform: translateY(0) scale(var(--mag,1)); } }
 .dock .dock-icon.bounce { animation: bounce 0.6s ease-out; }
 body.ios-mode .dock { background: rgba(255,255,255,0.9); border-color: rgba(0,0,0,0.2); box-shadow: 0 4px 12px rgba(0,0,0,0.15); border-radius: 10px; }
 
 /* iOS 4 SpringBoard */
-#springboard { display: none; grid-template-rows: 1fr auto; height: 100vh; padding: 24px 12px 64px; background: radial-gradient(circle at 30% 20%, #2d5bd1, #0f2a69 60%); }
+#springboard { display: none; grid-template-rows: 1fr auto; height: 100vh; padding: 24px 12px 64px; background:
+  radial-gradient(1200px 700px at 30% -10%, rgba(255,255,255,0.35), rgba(255,255,255,0) 60%),
+  radial-gradient(1000px 700px at 70% 120%, rgba(255,255,255,0.25), rgba(255,255,255,0) 60%),
+  linear-gradient(180deg, #3d74d8, #14305e 70%);
+}
 .springboard-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px 10px; align-content: start; }
-.sb-icon { display: grid; place-items: center; width: 64px; height: 64px; margin: 0 auto; border-radius: 14px; position: relative; box-shadow: 0 6px 14px rgba(0,0,0,0.35), inset 0 1px 0 rgba(255,255,255,0.55); background: linear-gradient(#7aa9ff, #2f6bff); }
-.sb-icon::after { content: ""; position: absolute; top: 0; left: 0; right: 0; height: 50%; border-radius: 14px 14px 10px 10px; background: linear-gradient(180deg, rgba(255,255,255,0.65), rgba(255,255,255,0)); pointer-events: none; }
+.sb-icon { display: grid; place-items: center; width: 64px; height: 64px; margin: 0 auto; border-radius: 11px; position: relative; box-shadow: 0 8px 16px rgba(0,0,0,0.45), inset 0 1px 0 rgba(255,255,255,0.6); background: linear-gradient(#86b5ff, #2d62e8); }
+.sb-icon::after { content: ""; position: absolute; top: 0; left: 0; right: 0; height: 50%; border-radius: 11px 11px 8px 8px; background: linear-gradient(180deg, rgba(255,255,255,0.65), rgba(255,255,255,0)); pointer-events: none; }
 .sb-label { text-align: center; color: #fff; font-size: 11px; margin-top: 6px; text-shadow: 0 1px 0 rgba(0,0,0,0.7); }
 .ios-dock { position: fixed; left: 50%; transform: translateX(-50%); bottom: 10px; width: calc(100% - 24px); max-width: 480px; height: 66px; padding: 8px 16px; background: rgba(255,255,255,0.25); border: 1px solid rgba(255,255,255,0.3); border-radius: 18px; -webkit-backdrop-filter: blur(12px) saturate(1.2); backdrop-filter: blur(12px) saturate(1.2); box-shadow: inset 0 1px 0 rgba(255,255,255,0.6), 0 10px 20px rgba(0,0,0,0.35); display: grid; grid-auto-flow: column; justify-content: space-between; align-items: end; }
-.ios-dock .sb-icon { width: 56px; height: 56px; border-radius: 12px; }
+.ios-dock .sb-icon { width: 56px; height: 56px; border-radius: 10px; }
 @keyframes jiggle { 0% { transform: rotate(-1.5deg) scale(0.98); } 50% { transform: rotate(1.5deg) scale(1.02); } 100% { transform: rotate(-1.5deg) scale(0.98); } }
 .jiggle .sb-icon { animation: jiggle 0.25s ease-in-out infinite; transform-origin: 50% 100%; }
 .home-button { display: none; position: fixed; bottom: 82px; left: 50%; transform: translateX(-50%); width: 58px; height: 58px; border-radius: 50%; background: radial-gradient(circle at 30% 30%, #fff, #e9e9e9); border: 1px solid rgba(0,0,0,0.4); box-shadow: 0 6px 14px rgba(0,0,0,0.25), inset 0 2px 0 rgba(255,255,255,0.8); }
+
+/* iOS App chrome */
+.ios-app { position: fixed; inset: 20px 12px 90px; background: #ffffff; border-radius: 12px; box-shadow: 0 18px 32px rgba(0,0,0,0.35); display: grid; grid-template-rows: 44px 1fr; overflow: hidden; }
+.ios-app[hidden] { display: none; }
+.ios-nav { display: grid; grid-template-columns: 70px 1fr 70px; align-items: center; height: 44px; background: linear-gradient(#5d85e6, #2450b6); color: #fff; box-shadow: inset 0 1px 0 rgba(255,255,255,0.7), 0 1px 0 rgba(0,0,0,0.35); }
+.ios-back { justify-self: start; margin-left: 8px; height: 28px; padding: 0 10px; border-radius: 6px; border: 1px solid rgba(0,0,0,0.35); color: #fff; background: linear-gradient(#6f96f0, #3d6fda); box-shadow: inset 0 1px 0 rgba(255,255,255,0.7), 0 1px 0 rgba(0,0,0,0.25); }
+.ios-title { justify-self: center; font-weight: 600; }
+.app-body { padding: 12px; overflow: auto; }
+
+/* iOS app open animation */
+@keyframes iosOpen { 0% { transform: scale(0.92); opacity: 0; } 100% { transform: scale(1); opacity: 1; } }
+.ios-app.opening { animation: iosOpen 240ms ease-out; transform-origin: 50% 50%; }
 
 /* Responsive: small screens open windows "maximized" */
 @media (max-width: 640px) {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -491,6 +491,9 @@
     if (!app) return;
     hideSpringboard();
     app.removeAttribute('hidden');
+    app.classList.remove('opening');
+    void app.offsetWidth;
+    app.classList.add('opening');
     document.getElementById('home-button')?.removeAttribute('hidden');
   }
   function showSpringboard() {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -459,7 +459,22 @@
     const overlay = document.getElementById('boot-overlay');
     if (!overlay) return;
     overlay.classList.add('active');
-    setTimeout(() => overlay.classList.remove('active'), 1400);
+    const bar = document.getElementById('boot-bar');
+    let progress = 0;
+    const step = () => {
+      progress += Math.random() * 18 + 6; // 6-24% steps
+      progress = Math.min(100, progress);
+      if (bar) {
+        bar.style.width = progress + '%';
+        bar.parentElement?.setAttribute('aria-valuenow', String(Math.floor(progress)));
+      }
+      if (progress < 100) {
+        setTimeout(step, 160);
+      } else {
+        setTimeout(() => overlay.classList.remove('active'), 260);
+      }
+    };
+    setTimeout(step, 180);
   }
 
   // iOS Mode

--- a/index.html
+++ b/index.html
@@ -26,7 +26,9 @@
       <div class="boot-apple" aria-hidden="true">
         <svg viewBox="0 0 24 24" width="40" height="40"><path d="M16.365 12.72c.012 1.96 1.72 2.613 1.733 2.62-.014.045-.27.92-.888 1.82-.534.78-1.09 1.56-1.965 1.58-.858.016-1.135-.51-2.12-.51-.984 0-1.29.495-2.106.525-.85.03-1.497-.84-2.035-1.62-1.108-1.61-1.95-4.545-1.353-6.535.936-3.03 3.642-3.28 3.964-3.28.85-.08 1.66.57 2.12.57.45 0 1.39-.7 2.34-.6.4.017 1.525.16 2.25 1.19-.06.037-1.342.78-1.34 2.34m-1.57-6.81c.41-.5.69-1.2.62-1.91-.6.025-1.33.4-1.77.9-.392.45-.72 1.17-.63 1.86.67.05 1.36-.35 1.78-.85" fill="#fff"/></svg>
       </div>
-      <div class="boot-spinner" aria-hidden="true"></div>
+      <div class="boot-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Loading">
+        <div id="boot-bar" class="boot-bar"></div>
+      </div>
     </div>
   </div>
   <!-- Menu Bar -->

--- a/index.html
+++ b/index.html
@@ -161,26 +161,49 @@
     </ul>
   </main>
 
+  <!-- iOS 4 Lock Screen -->
+  <div id="lock-screen" role="dialog" aria-label="Lock Screen" hidden>
+    <div class="lock-bg"></div>
+    <div class="lock-time" id="lock-time">12:00</div>
+    <div class="lock-slider" id="lock-slider" aria-label="Slide to unlock">
+      <div class="slider-track"><span>slide to unlock</span></div>
+      <div class="slider-thumb" role="button" tabindex="0" aria-label="Unlock"></div>
+    </div>
+  </div>
+
   <!-- iOS SpringBoard (shown in iOS mode) -->
   <div id="springboard" role="application" aria-label="iPhone Home" hidden>
-    <div class="springboard-grid">
-      <div>
-        <button class="sb-icon" data-app="ios-about" aria-label="About"></button>
-        <div class="sb-label">About</div>
+    <div class="sb-pages" id="sb-pages">
+      <div class="sb-page">
+        <div class="springboard-grid">
+          <div>
+            <button class="sb-icon" data-app="ios-about" aria-label="About"></button>
+            <div class="sb-label">About</div>
+          </div>
+          <div>
+            <button class="sb-icon" data-app="ios-projects" aria-label="Projects"></button>
+            <div class="sb-label">Projects</div>
+          </div>
+          <div>
+            <button class="sb-icon" data-app="ios-blog" aria-label="Blog"></button>
+            <div class="sb-label">Blog</div>
+          </div>
+          <div>
+            <button class="sb-icon" data-app="ios-contact" aria-label="Contact"></button>
+            <div class="sb-label">Contact</div>
+          </div>
+        </div>
       </div>
-      <div>
-        <button class="sb-icon" data-app="ios-projects" aria-label="Projects"></button>
-        <div class="sb-label">Projects</div>
-      </div>
-      <div>
-        <button class="sb-icon" data-app="ios-blog" aria-label="Blog"></button>
-        <div class="sb-label">Blog</div>
-      </div>
-      <div>
-        <button class="sb-icon" data-app="ios-contact" aria-label="Contact"></button>
-        <div class="sb-label">Contact</div>
+      <div class="sb-page">
+        <div class="springboard-grid">
+          <div>
+            <a class="sb-icon" href="https://www.linkedin.com/in/reza-jalaei/" target="_blank" rel="noopener" aria-label="Resume"></a>
+            <div class="sb-label">Resume</div>
+          </div>
+        </div>
       </div>
     </div>
+    <div class="page-dots" id="page-dots" aria-hidden="true"><span class="active" data-page="0"></span><span data-page="1"></span></div>
     <div class="ios-dock" aria-hidden="true">
       <button class="sb-icon" data-app="ios-about" aria-label="About"></button>
       <button class="sb-icon" data-app="ios-projects" aria-label="Projects"></button>

--- a/index.html
+++ b/index.html
@@ -41,6 +41,8 @@
         <li role="menuitem" data-action="about-this-mac">About This Mac</li>
         <li class="separator" role="separator"></li>
         <li role="menuitem" data-action="about-this-site">About This Site</li>
+        <li class="separator" role="separator"></li>
+        <li role="menuitem" data-action="switch-to-iphone">Switch to iPhone</li>
       </ul>
       <div class="app-name" aria-hidden="true">Finder</div>
       <nav class="menus">
@@ -158,6 +160,35 @@
       </li>
     </ul>
   </main>
+
+  <!-- iOS SpringBoard (shown in iOS mode) -->
+  <div id="springboard" role="application" aria-label="iPhone Home" hidden>
+    <div class="springboard-grid">
+      <div>
+        <button class="sb-icon" data-app="ios-about" aria-label="About"></button>
+        <div class="sb-label">About</div>
+      </div>
+      <div>
+        <button class="sb-icon" data-app="ios-projects" aria-label="Projects"></button>
+        <div class="sb-label">Projects</div>
+      </div>
+      <div>
+        <button class="sb-icon" data-app="ios-blog" aria-label="Blog"></button>
+        <div class="sb-label">Blog</div>
+      </div>
+      <div>
+        <button class="sb-icon" data-app="ios-contact" aria-label="Contact"></button>
+        <div class="sb-label">Contact</div>
+      </div>
+    </div>
+    <div class="ios-dock" aria-hidden="true">
+      <button class="sb-icon" data-app="ios-about" aria-label="About"></button>
+      <button class="sb-icon" data-app="ios-projects" aria-label="Projects"></button>
+      <button class="sb-icon" data-app="ios-blog" aria-label="Blog"></button>
+      <button class="sb-icon" data-app="ios-contact" aria-label="Contact"></button>
+    </div>
+  </div>
+  <button id="home-button" class="home-button" aria-label="Home" hidden></button>
 
   <!-- Windows -->
   <section id="win-about" class="mac-window platinum" role="dialog" aria-labelledby="title-about" aria-modal="false" hidden>
@@ -281,6 +312,24 @@
       </div>
     </div>
     <div class="resize-handle" aria-hidden="true"></div>
+  </section>
+
+  <!-- iOS App Containers -->
+  <section id="ios-about" class="ios-app" role="dialog" aria-label="About" hidden>
+    <div class="ios-nav"><button class="ios-back" aria-label="Home">Home</button><div class="ios-title">About</div></div>
+    <div class="app-body"></div>
+  </section>
+  <section id="ios-projects" class="ios-app" role="dialog" aria-label="Projects" hidden>
+    <div class="ios-nav"><button class="ios-back" aria-label="Home">Home</button><div class="ios-title">Projects</div></div>
+    <div class="app-body"></div>
+  </section>
+  <section id="ios-blog" class="ios-app" role="dialog" aria-label="Blog" hidden>
+    <div class="ios-nav"><button class="ios-back" aria-label="Home">Home</button><div class="ios-title">Blog</div></div>
+    <div class="app-body"></div>
+  </section>
+  <section id="ios-contact" class="ios-app" role="dialog" aria-label="Contact" hidden>
+    <div class="ios-nav"><button class="ios-back" aria-label="Home">Home</button><div class="ios-title">Contact</div></div>
+    <div class="app-body"></div>
   </section>
 
   <script src="assets/js/main.js"></script>


### PR DESCRIPTION
Adds a dual macOS 10.0 Aqua and iOS 4 SpringBoard UI to the portfolio website, integrating existing content and interactive elements.

---
<a href="https://cursor.com/background-agent?bcId=bc-a534e251-c459-4a16-ae43-1bf8c6d84869">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a534e251-c459-4a16-ae43-1bf8c6d84869">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

